### PR TITLE
add docker-credential-helper as a conflict formula

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -27,6 +27,7 @@ cask "docker" do
     docker-completion
     docker-compose
     docker-compose-completion
+    docker-credential-helper
     docker-credential-helper-ecr
     hyperkit
     kubernetes-cli


### PR DESCRIPTION
Docker Desktop installs and links binary `/usr/local/bin/docker-credential-osxkeychain` which is the only binary `docker-credential-helper` formula installs.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
